### PR TITLE
[Don't merge] Introduce new metric protocol 

### DIFF
--- a/common/common.proto
+++ b/common/common.proto
@@ -32,6 +32,11 @@ message KeyIntValuePair {
     int32 value = 2;
 }
 
+message IntKeyIntValuePair {
+    int32 key = 1;
+    int32 value = 2;
+}
+
 message CPU {
     double usagePercent = 2;
 }

--- a/metric/metric.proto
+++ b/metric/metric.proto
@@ -57,14 +57,20 @@ message RelationMetric {
         Endpoint dest_endpoint = 6;
     }
 
-    repeated Metric metrics = 7;
+    Metric metric = 7;
 }
 
 message Metric {
+    oneof identify {
+        string name = 1;
+        int32 id = 2;
+    }
+
+    int64 time = 3;
     Type type = 4;
 
-    Gauge gaugeValues = 5;
-    Histogram histogramValues = 6;
+    repeated Gauge gaugeValues = 5;
+    repeated Histogram histogramValues = 6;
 
     enum Type {
         GAUGE = 0;
@@ -72,12 +78,10 @@ message Metric {
     }
 
     message Gauge {
-        string name = 1;
         int64 value = 2;
     }
 
     message Histogram {
-        string name = 1;
         repeated IntKeyIntValuePair values = 2;
     }
 }

--- a/metric/metric.proto
+++ b/metric/metric.proto
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.apache.skywalking.apm.network.metric";
+option csharp_namespace = "SkyWalking.NetworkProtocol";
+
+import "register/Register.proto";
+import "common/common.proto";
+
+
+service MetricService {
+    rpc reportEntityMetric (stream EntityMetric) returns (MetricResponse) {
+    }
+
+    rpc reportRelationMetric (stream RelationMetric) returns (MetricResponse) {
+    }
+}
+
+message EntityMetric {
+    oneof metric_entity {
+        Service service = 1;
+        ServiceInstance service_instance = 2;
+        Endpoint endpoint = 3;
+    }
+
+    repeated Metric metrics = 4;
+}
+
+message RelationMetric {
+    oneof source_entity {
+        Service source_service = 1;
+        ServiceInstance source_service_instance = 2;
+        Endpoint source_endpoint = 3;
+    }
+
+    oneof dest_entity {
+        Service dest_service = 4;
+        ServiceInstance dest_service_instance = 5;
+        Endpoint dest_endpoint = 6;
+    }
+
+    repeated Metric metrics = 7;
+}
+
+message Metric {
+    Type type = 4;
+
+    Gauge gaugeValues = 5;
+    Histogram histogramValues = 6;
+
+    enum Type {
+        GAUGE = 0;
+        HISTOGRAM = 1;
+    }
+
+    message Gauge {
+        string name = 1;
+        int64 value = 2;
+    }
+
+    message Histogram {
+        string name = 1;
+        repeated IntKeyIntValuePair values = 2;
+    }
+}
+
+message MetricResponse {
+
+}

--- a/metric/metric.proto
+++ b/metric/metric.proto
@@ -36,9 +36,9 @@ service MetricService {
 
 message EntityMetric {
     oneof metric_entity {
-        Service service = 1;
-        ServiceInstance service_instance = 2;
-        Endpoint endpoint = 3;
+        int32 service_id = 1;
+        int32 service_instance_id = 2;
+        int32 endpoint_id = 3;
     }
 
     repeated Metric metrics = 4;
@@ -46,15 +46,15 @@ message EntityMetric {
 
 message RelationMetric {
     oneof source_entity {
-        Service source_service = 1;
-        ServiceInstance source_service_instance = 2;
-        Endpoint source_endpoint = 3;
+        int32 source_service_id = 1;
+        int32 source_service_instance_id = 2;
+        int32 source_endpoint_id = 3;
     }
 
     oneof dest_entity {
-        Service dest_service = 4;
-        ServiceInstance dest_service_instance = 5;
-        Endpoint dest_endpoint = 6;
+        int32 dest_service_id = 4;
+        int32 dest_service_instance_id = 5;
+        int32 dest_endpoint_id = 6;
     }
 
     Metric metric = 7;

--- a/register/Register.proto
+++ b/register/Register.proto
@@ -32,7 +32,7 @@ service Register {
     rpc doServiceInstanceRegister (ServiceInstances) returns (ServiceInstanceRegisterMapping) {
     }
 
-    rpc doEndpointRegister (Enpoints) returns (EndpointMapping) {
+    rpc doEndpointRegister (Endpoints) returns (EndpointMapping) {
     }
 
     rpc doNetworkAddressRegister (NetAddresses) returns (NetAddressMapping) {
@@ -87,7 +87,7 @@ message NetAddressMapping {
 }
 
 // Endpint register
-message Enpoints {
+message Endpoints {
     repeated Endpoint endpoints = 1;
 }
 


### PR DESCRIPTION
We have provided service mesh as a new way, which work well with istio, and I am trying to work with envoy too, in https://github.com/apache/incubator-skywalking/pull/2460 

This pull request brings the new metric protocol to SkyWalking. For many cases, people haven't needed to understand tracing, but they want our analysis and visualize metrics and topology.

Through this protocol, client lib could do more simple works.
1. Register
1. Report metric of node
1. Report metric of nodes relationship, which could make topology and metrics too.

The data types are gauge and histogram, like most people knew.

Please review. @tristaZero @terrymanu @WillemJiang as ShardingSphere and ServiceComb are most likely the first two adopt this API.



