### PR TITLE
Add Apache license header for skywalking.config.pb.html

### DIFF
--- a/service-mesh-probe/istio/skywalking.config.pb.html
+++ b/service-mesh-probe/istio/skywalking.config.pb.html
@@ -1,3 +1,16 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+ 
 ---
 title: Apache SkyWalking
 description: Adapter to deliver metrics to Apache SkyWalking.


### PR DESCRIPTION
Add Apache license header for skywalking.config.pb.html.
Ref: apache/skywalking#2531
/cc @wu-sheng 