### PR TITLE
build: generating mock entity to build gRPC C++ Stub

### DIFF
--- a/language-agent/BUILD
+++ b/language-agent/BUILD
@@ -39,4 +39,5 @@ cc_grpc_library(
   srcs = [":tracing_protocol_proto_lib"],
   deps = [":tracing_protocol_cc_proto"],
   grpc_only = True,
+  generate_mocks = True,
 )


### PR DESCRIPTION
It enables to generate GoogleMock compatible mock entity creating unit-test in C++.