### PR TITLE
Fix C# compilation conflicts

### DIFF
--- a/browser/BrowserPerfCompat.proto
+++ b/browser/BrowserPerfCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 option deprecated = true;
 

--- a/language-agent/CLRMetricCompat.proto
+++ b/language-agent/CLRMetricCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 option deprecated = true;
 

--- a/language-agent/JVMMetricCompat.proto
+++ b/language-agent/JVMMetricCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 option deprecated = true;
 

--- a/language-agent/MeterCompat.proto
+++ b/language-agent/MeterCompat.proto
@@ -21,6 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/language-agent/TracingCompat.proto
+++ b/language-agent/TracingCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 option deprecated = true;
 

--- a/management/ManagementCompat.proto
+++ b/management/ManagementCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.management.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/management/v3";
 option deprecated = true;
 

--- a/profile/ProfileCompat.proto
+++ b/profile/ProfileCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.profile.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/profile/v3";
 option deprecated = true;
 

--- a/service-mesh-probe/service-mesh-compat.proto
+++ b/service-mesh-probe/service-mesh-compat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.servicemesh.v3.compat";
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/servicemesh/v3";
 option deprecated = true;
 


### PR DESCRIPTION
When I pull the latest protocol in skyapm-dotnet, building the project throws the following errors
```
Error: /home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/generated-v3/browser/BrowserPerfGrpc.cs(52,18): error CS0102: The type 'BrowserPerfService' already contains a definition for '__Helper_MessageCache' [/home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj]
Error: /home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/generated-v3/browser/BrowserPerfGrpc.cs(34,28): error CS0102: The type 'BrowserPerfService' already contains a definition for '__ServiceName' [/home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj]
Error: /home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/generated-v3/browser/BrowserPerfGrpc.cs(37,17): error CS0111: Type 'BrowserPerfService' already defines a member called '__Helper_SerializeMessage' with the same parameter types [/home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj]
Error: /home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/generated-v3/browser/BrowserPerfGrpc.cs(58,14): error CS0111: Type 'BrowserPerfService' already defines a member called '__Helper_DeserializeMessage' with the same parameter types [/home/runner/work/SkyAPM-dotnet/SkyAPM-dotnet/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj]
...
```
I fixed it by giving the *compat.proto the new namespace.