### PR TITLE
Update compat package path in go for satellite

### DIFF
--- a/browser/BrowserPerfCompat.proto
+++ b/browser/BrowserPerfCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/language-agent/CLRMetricCompat.proto
+++ b/language-agent/CLRMetricCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/language-agent/JVMMetricCompat.proto
+++ b/language-agent/JVMMetricCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/language-agent/MeterCompat.proto
+++ b/language-agent/MeterCompat.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option deprecated = true;
 

--- a/language-agent/TracingCompat.proto
+++ b/language-agent/TracingCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/management/ManagementCompat.proto
+++ b/management/ManagementCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.management.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/management/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/management/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/profile/ProfileCompat.proto
+++ b/profile/ProfileCompat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.profile.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/profile/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/profile/v3/compat";
 option deprecated = true;
 
 import "common/Common.proto";

--- a/service-mesh-probe/service-mesh-compat.proto
+++ b/service-mesh-probe/service-mesh-compat.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.servicemesh.v3.compat";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
-option go_package = "skywalking.apache.org/repo/goapi/collect/servicemesh/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/servicemesh/v3/compat";
 option deprecated = true;
 
 import "service-mesh-probe/service-mesh.proto";


### PR DESCRIPTION
Now, we are using satellite as the gateway, but some agents using the old version data collection protocol. 
We need to let the satellite also could transmit them, but the compatible version of the protocol is duplicated with the current version of the go package path. 

So need to change the go package path in the compatible protocol. 