### PR TITLE
Add Golang Runtime Metrics

### DIFF
--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 package skywalking.v3;
 
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
-option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+option go_package = "github.com/easonyipj/skywalking-goapi/collect/language/agent/v3";
 
 import "common/Common.proto";
 

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 
 package skywalking.v3;
 
-option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option java_package = "org.apache.skywalking.apm.network.language.agent.v3";
 option go_package = "github.com/easonyipj/skywalking-goapi/collect/language/agent/v3";
 
 import "common/Common.proto";

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -21,7 +21,7 @@ syntax = "proto3";
 package skywalking.v3;
 
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3";
-option go_package = "github.com/easonyipj/skywalking-goapi/collect/language/agent/v3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 
 import "common/Common.proto";
 

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -41,7 +41,7 @@ message GolangMetric {
   int64 time = 1;
   int64 heapAlloc = 2;
   int64 stackInUse = 3;
-  int64 gcNum = 4;
+  uint32 gcNum = 4;
   float gcPauseTime = 5;
   int64 goroutineNum = 6;
   int64 threadNum = 7;

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -41,7 +41,7 @@ message GolangMetric {
   int64 time = 1;
   int64 heapAlloc = 2;
   int64 stackInUse = 3;
-  uint32 gcNum = 4;
+  int64 gcNum = 4;
   float gcPauseTime = 5;
   int64 goroutineNum = 6;
   int64 threadNum = 7;

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -42,7 +42,7 @@ message GolangMetric {
   int64 heapAlloc = 2;
   int64 stackInUse = 3;
   int64 gcNum = 4;
-  float gcPauseTime = 5;
+  int64 gcPauseTime = 5;
   int64 goroutineNum = 6;
   int64 threadNum = 7;
   float cpuUsedRate = 8;

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -45,6 +45,6 @@ message GolangMetric {
   int64 gcPauseTime = 5;
   int64 goroutineNum = 6;
   int64 threadNum = 7;
-  int64 cpuUsedRate = 8;
-  int64 memUsedRate = 9;
+  float cpuUsedRate = 8;
+  float memUsedRate = 9;
 }

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -42,7 +42,7 @@ message GolangMetric {
   int64 heapAlloc = 2;
   int64 stackInUse = 3;
   int64 gcNum = 4;
-  int64 gcPauseTime = 5;
+  float gcPauseTime = 5;
   int64 goroutineNum = 6;
   int64 threadNum = 7;
   float cpuUsedRate = 8;

--- a/language-agent/GolangMetric.proto
+++ b/language-agent/GolangMetric.proto
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+syntax = "proto3";
+
+package skywalking.v3;
+
+option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
+option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
+
+import "common/Common.proto";
+
+// Define the Golang metrics report service.
+service GolangMetricReportService {
+  rpc collect (GolangMetricCollection) returns (Commands) {
+  }
+}
+
+message GolangMetricCollection {
+  repeated GolangMetric metrics = 1;
+  string service = 2;
+  string serviceInstance = 3;
+}
+
+message GolangMetric {
+  int64 time = 1;
+  int64 heapAlloc = 2;
+  int64 stackInUse = 3;
+  int64 gcNum = 4;
+  int64 gcPauseTime = 5;
+  int64 goroutineNum = 6;
+  int64 threadNum = 7;
+  int64 cpuUsedRate = 8;
+  int64 memUsedRate = 9;
+}


### PR DESCRIPTION
Add some golang runtime metrics:
time : the Unix time when metrics were collected
heapAlloc: the bytes of allocated heap objects
stackInUse: the bytes in stack spans.
gcNum: the number of completed GC cycles during collect cycle（5s）
gcPauseTime：the latest gc pause time(NS)
goroutineNum：the number of goroutines that currently exist
threadNum：the number of records in the thread creation profile
cpuUsedRate：the cpu Used float64
memUsedRate: the Percentage of RAM used by programs