### PR TITLE
Support SpanAttachedEvent

### DIFF
--- a/common/Common.proto
+++ b/common/Common.proto
@@ -30,6 +30,13 @@ message KeyStringValuePair {
     string value = 2;
 }
 
+// since v3.1
+// An extension of KeyStringValuePair represents a kind of metric value for the key.
+message KeyIntValuePair {
+    string key = 1;
+    int64 value = 2;
+}
+
 message CPU {
     double usagePercent = 2;
 }
@@ -50,5 +57,18 @@ message Commands {
 message Command {
     string command = 1;
     repeated KeyStringValuePair args = 2;
+}
+
+// since v3.1
+// An instantaneous point on the time-line.
+// An instance represents a data point accurate to the nanosecond.
+// It is constituted by a long representing epoch-seconds and an int representing nanosecond-of-second,
+// which will always be between 0 and 999,999,999
+message Instant {
+    // The number of seconds from the epoch of 1970-01-01T00:00:00Z.
+    int64 seconds = 1;
+    // The number of nanoseconds, later along the time-line, from the seconds field.
+    // This is always positive, and never exceeds 999,999,999.
+    int32 nanos = 2;
 }
 

--- a/common/Common.proto
+++ b/common/Common.proto
@@ -61,7 +61,7 @@ message Command {
 
 // since v3.1
 // An instantaneous point on the time-line.
-// An instance represents a data point accurate to the nanosecond.
+// An instant represents a data point accurate to the nanosecond.
 // It is constituted by a long representing epoch-seconds and an int representing nanosecond-of-second,
 // which will always be between 0 and 999,999,999
 message Instant {

--- a/language-agent/Tracing.proto
+++ b/language-agent/Tracing.proto
@@ -236,9 +236,9 @@ service SpanAttachedEventReportService {
 
 // SpanAttachedEvent represents an attached event for a traced RPC.
 //
-// When a RPC is being traced by the in-process language agent, a span would be reported by client-side agent.
+// When an RPC is being traced by the in-process language agent, a span would be reported by the client-side agent.
 // And the rover would be aware of this RPC due to the existing tracing header.
-// Then, rover agent collects extra information from OS level to provide assist information to diagnose network performance.
+// Then, the rover agent collects extra information from the OS level to provide assistance information to diagnose network performance.
 message SpanAttachedEvent {
     // The nanosecond timestamp of the event's start time.
     // Notice, most unit of timestamp in SkyWalking is milliseconds, but NANO-SECOND is required here.

--- a/language-agent/Tracing.proto
+++ b/language-agent/Tracing.proto
@@ -223,3 +223,62 @@ enum SpanLayer {
 message SegmentCollection {
     repeated SegmentObject segments = 1;
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// ebpf agent(SkyWalking Rover) collects extra information from the OS(Linux Only) level to attach on the traced span.
+// Since v3.1
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+service SpanAttachedEventReportService {
+    // Collect SpanAttachedEvent to the OAP server in the streaming mode.
+    rpc collect (stream SpanAttachedEvent) returns (Commands) {
+    }
+}
+
+// SpanAttachedEvent represents an attached event for a traced RPC.
+//
+// When a RPC is being traced by the in-process language agent, a span would be reported by client-side agent.
+// And the rover would be aware of this RPC due to the existing tracing header.
+// Then, rover agent collects extra information from OS level to provide assist information to diagnose network performance.
+message SpanAttachedEvent {
+    // The nanosecond timestamp of the event's start time.
+    // Notice, most unit of timestamp in SkyWalking is milliseconds, but NANO-SECOND is required here.
+    // Because the attached event happens in the OS syscall level, most of them are executed rapidly.
+    Instant startTime = 1;
+    // The official event name.
+    // For example, the event name is a method signature from syscall stack.
+    string event = 2;
+    // [Optional] The nanosecond timestamp of the event's end time.
+    Instant endTime = 3;
+    // The tags for this event includes some extra OS level information,
+    // such as
+    // 1. net_device used for this exit span.
+    // 2. network L7 protocol
+    repeated KeyStringValuePair tags = 4;
+    // The summary of statistics during this event.
+    // Each statistic provides a name(metric name) to represent the name, and an int64/long as the value.
+    repeated KeyIntValuePair summary = 5;
+    // Refer to a trace context decoded from `sw8` header through network, such as HTTP header, MQ metadata
+    // https://skywalking.apache.org/docs/main/next/en/protocols/skywalking-cross-process-propagation-headers-protocol-v3/#standard-header-item
+    SpanReference traceContext = 6;
+
+    message SpanReference {
+        SpanReferenceType type = 1;
+        // [Optional] A string id represents the whole trace.
+        string traceId = 2;
+        // A unique id represents this segment. Other segments could use this id to reference as a child segment.
+        // [Optional] when this span reference
+        string traceSegmentId = 3;
+        // If type == SKYWALKING
+        // The number id of the span. Should be unique in the whole segment.
+        // Starting at 0
+        //
+        // If type == ZIPKIN
+        // The type of span ID is string.
+        string spanId = 4;
+    }
+
+    enum SpanReferenceType {
+        SKYWALKING = 0;
+        ZIPKIN = 1;
+    }
+}


### PR DESCRIPTION
FYI @apache/skywalking-committers 

This is a new extension and the first one after [Trace Data Protocol v3](https://skywalking.apache.org/docs/main/next/en/protocols/trace-data-protocol-v3/). So I marked this as v3.1, the main document would be updated once this is really implemented.

## Case Scenario
When an RPC is being traced by the in-process language agent, a span would be reported by the client-side agent.
And the rover would be aware of this RPC due to the existing tracing header.
Then, the rover agent collects extra information from the OS level to provide assistance information to diagnose network performance.

## Who is going to implement this
The Rover(ebpf) agent would implement this. This relies on the rover agent having the capability to decode HTTP(at least) header and body on the fly.