### PR TITLE
Remove unnecessary protocol import

### DIFF
--- a/browser/BrowserPerf.proto
+++ b/browser/BrowserPerf.proto
@@ -25,7 +25,6 @@ option java_package = "org.apache.skywalking.apm.network.language.agent.v3";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 // Collect performance raw data from browser.

--- a/browser/BrowserPerfCompat.proto
+++ b/browser/BrowserPerfCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "browser/BrowserPerf.proto";
 

--- a/ebpf/profiling/Profile.proto
+++ b/ebpf/profiling/Profile.proto
@@ -24,7 +24,6 @@ option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.ebpf.profiling.v3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/ebpf/profiling/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 // Define the Rover Process profiling task and upload profiling data.

--- a/event/Event.proto
+++ b/event/Event.proto
@@ -25,7 +25,6 @@ option java_package = "org.apache.skywalking.apm.network.event.v3";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/event/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 service EventService {

--- a/language-agent/CLRMetricCompat.proto
+++ b/language-agent/CLRMetricCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "language-agent/CLRMetric.proto";
 

--- a/language-agent/ConfigurationDiscoveryService.proto
+++ b/language-agent/ConfigurationDiscoveryService.proto
@@ -25,7 +25,6 @@ option java_package = "org.apache.skywalking.apm.network.language.agent.v3";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/agent/configuration/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 // Fetch the latest dynamic configurations of the service.

--- a/language-agent/JVMMetricCompat.proto
+++ b/language-agent/JVMMetricCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "language-agent/JVMMetric.proto";
 

--- a/language-agent/Meter.proto
+++ b/language-agent/Meter.proto
@@ -24,7 +24,6 @@ option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent.v3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 service MeterReportService {

--- a/language-agent/MeterCompat.proto
+++ b/language-agent/MeterCompat.proto
@@ -24,7 +24,6 @@ option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "language-agent/Meter.proto";
 

--- a/language-agent/TracingCompat.proto
+++ b/language-agent/TracingCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/agent/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "language-agent/Tracing.proto";
 

--- a/management/ManagementCompat.proto
+++ b/management/ManagementCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/management/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "management/Management.proto";
 

--- a/profile/Profile.proto
+++ b/profile/Profile.proto
@@ -25,7 +25,6 @@ option java_package = "org.apache.skywalking.apm.network.language.profile.v3";
 option csharp_namespace = "SkyWalking.NetworkProtocol.V3";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/profile/v3";
 
-import "common/Common.proto";
 import "common/Command.proto";
 
 service ProfileTask {

--- a/profile/ProfileCompat.proto
+++ b/profile/ProfileCompat.proto
@@ -24,7 +24,6 @@ option csharp_namespace = "SkyWalking.NetworkProtocol.V3.Compat";
 option go_package = "skywalking.apache.org/repo/goapi/collect/language/profile/v3/compat";
 option deprecated = true;
 
-import "common/Common.proto";
 import "common/Command.proto";
 import "profile/Profile.proto";
 


### PR DESCRIPTION
After splitting the command as a new protocol file, I found their output some warning log when generating the gRPC code.
So I remove the `common` protocol in some protocol files. 
![image](https://user-images.githubusercontent.com/3417650/203464854-b01fd08e-1b1d-46e1-9d72-f6ad36f556bc.png)
