### PR TITLE
Adding fields into access log protocol

### DIFF
--- a/ebpf/accesslog.proto
+++ b/ebpf/accesslog.proto
@@ -51,6 +51,8 @@ message EBPFAccessLogNodeInfo {
     repeated EBPFAccessLogNodeNetInterface netInterfaces = 2;
     // System boot time
     Instant bootTime = 3;
+    // Cluster name
+    string clusterName = 4;
 }
 
 message EBPFAccessLogNodeNetInterface {
@@ -69,6 +71,8 @@ message AccessLogConnection {
     DetectPoint role = 3;
     // is the connection using TLS or not
     AccessLogConnectionTLSMode tlsMode = 4;
+    // application protocol type
+    AccessLogProtocolType protocol = 5;
 }
 
 message ConnectionAddress {
@@ -325,6 +329,11 @@ enum AccessLogKernelReadSyscall {
     RecvFrom = 3;
     RecvMsg = 4;
     RecvMmsg = 5;
+}
+
+enum AccessLogProtocolType {
+    Unknown = 0;
+    HTTP = 1;
 }
 
 message EBPFTimestamp {

--- a/ebpf/accesslog.proto
+++ b/ebpf/accesslog.proto
@@ -332,7 +332,7 @@ enum AccessLogKernelReadSyscall {
 }
 
 enum AccessLogProtocolType {
-    Unknown = 0;
+    TCP = 0;
     HTTP = 1;
 }
 


### PR DESCRIPTION
1. Add a `cluster` field to assist in building Kubernetes service names on the backend.
2. Add a `protocol` field to declare the protocol in the connection.