### PR TITLE
Update protocol type in access log

### DIFF
--- a/ebpf/accesslog.proto
+++ b/ebpf/accesslog.proto
@@ -333,7 +333,8 @@ enum AccessLogKernelReadSyscall {
 
 enum AccessLogProtocolType {
     TCP = 0;
-    HTTP = 1;
+    HTTP_1 = 1;
+    HTTP_2 = 2;
 }
 
 message EBPFTimestamp {


### PR DESCRIPTION
Because we share all the package `skywalking.v3`, the enum value name must be unique. So I update the protocol with separate `HTTP_1` and `HTTP_2`.