### PR TITLE
fix import of command.proto

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -23,5 +23,8 @@ licenses(["notice"])  # Apache 2
 
 proto_library(
   name = "common_protocol_proto_lib",
-  srcs = ["Common.proto"],
+  srcs = [
+      "Command.proto",
+      "Common.proto",
+  ],
 )


### PR DESCRIPTION
The `Command.proto` is not list in the `srcs` of proto_library which result in the importing error. See https://dev.azure.com/cncf/envoy/_build/results?buildId=178182&view=logs&jobId=a5c40c1c-4188-59f6-315a-dffba762bd05&j=a5c40c1c-4188-59f6-315a-dffba762bd05&t=a5d95ceb-8abe-5c0f-9f51-430dea9ce070