### PR TITLE
feat: update Bazel configuration and dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,4 +15,6 @@
 # limitations under the License.
 #
 
+common --enable_bzlmod
+
 try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # Bazel artifacts
-/bazel-bin
-/bazel-out
-/bazel-skywalking-data-collect-protocol
-/bazel-testlogs
+/bazel-*
+MODULE.bazel.lock
 
 .idea

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,16 +15,12 @@
 # limitations under the License.
 #
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2
-
-proto_library(
-    name = "common_protocol_proto_lib",
-    srcs = [
-        "Command.proto",
-        "Common.proto",
-    ],
+module(
+    name = "skywalking-data-collect-protocol",
+    version = "10.2.1-dev",
+    repo_name = "skywalking_data_collect_protocol",
 )
+
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "grpc", version = "1.74.1", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "protobuf", version = "32.0", repo_name = "com_google_protobuf")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,11 +21,9 @@ load("//bazel:repositories.bzl", "skywalking_data_collect_protocol_dependencies"
 
 skywalking_data_collect_protocol_dependencies()
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
-
-rules_proto_toolchains()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
@@ -34,3 +32,7 @@ grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -15,16 +15,4 @@
 # limitations under the License.
 #
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2
-
-proto_library(
-    name = "common_protocol_proto_lib",
-    srcs = [
-        "Command.proto",
-        "Common.proto",
-    ],
-)
+workspace(name = "skywalking_data_collect_protocol")

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,4 +1,3 @@
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -18,24 +18,26 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def skywalking_data_collect_protocol_dependencies():
-  rules_proto()
-  com_github_grpc_grpc()
+    if "rules_proto" not in native.existing_rules():
+        http_archive(
+            name = "rules_proto",
+            sha256 = "14a225870ab4e91869652cfd69ef2028277fc1dc4910d65d353b62d6e0ae21f4",
+            strip_prefix = "rules_proto-7.1.0",
+            urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
+        )
 
-def com_github_grpc_grpc():
-  http_archive(
-    name = "com_github_grpc_grpc",
-    sha256 = "3ccc4e5ae8c1ce844456e39cc11f1c991a7da74396faabe83d779836ef449bce",
-    urls = ["https://github.com/grpc/grpc/archive/v1.27.0.tar.gz"],
-    strip_prefix = "grpc-1.27.0",
-  )
+    if "com_github_grpc_grpc" not in native.existing_rules():
+        http_archive(
+            name = "com_github_grpc_grpc",
+            sha256 = "7bf97c11cf3808d650a3a025bbf9c5f922c844a590826285067765dfd055d228",
+            urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
+            strip_prefix = "grpc-1.74.1",
+        )
 
-def rules_proto():
-  http_archive(
-    name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-    ],
-  )
+    if "com_google_protobuf" not in native.existing_rules():
+        http_archive(
+            name = "com_google_protobuf",
+            sha256 = "3ad017543e502ffaa9cd1f4bd4fe96cf117ce7175970f191705fa0518aff80cd",
+            urls = ["https://github.com/google/protobuf/archive/refs/tags/v32.0.tar.gz"],
+            strip_prefix = "protobuf-32.0",
+        )

--- a/language-agent/BUILD
+++ b/language-agent/BUILD
@@ -15,48 +15,48 @@
 # limitations under the License.
 #
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2
 
 proto_library(
-  name = "tracing_protocol_proto_lib",
-  srcs = ["Tracing.proto"],
-  deps = ["//common:common_protocol_proto_lib"],
+    name = "tracing_protocol_proto_lib",
+    srcs = ["Tracing.proto"],
+    deps = ["//common:common_protocol_proto_lib"],
 )
 
 cc_proto_library(
-  name = "tracing_protocol_cc_proto",
-  deps = [":tracing_protocol_proto_lib"],
+    name = "tracing_protocol_cc_proto",
+    deps = [":tracing_protocol_proto_lib"],
 )
 
 cc_grpc_library(
-  name = "tracing_protocol_cc_grpc",
-  srcs = [":tracing_protocol_proto_lib"],
-  deps = [":tracing_protocol_cc_proto"],
-  grpc_only = True,
-  generate_mocks = True,
+    name = "tracing_protocol_cc_grpc",
+    srcs = [":tracing_protocol_proto_lib"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":tracing_protocol_cc_proto"],
 )
 
 proto_library(
-  name = "configuration_discovery_service_proto_lib",
-  srcs = ["ConfigurationDiscoveryService.proto"],
-  deps = ["//common:common_protocol_proto_lib"],
+    name = "configuration_discovery_service_proto_lib",
+    srcs = ["ConfigurationDiscoveryService.proto"],
+    deps = ["//common:common_protocol_proto_lib"],
 )
 
 cc_proto_library(
-  name = "configuration_discovery_service_cc_proto",
-  deps = [":configuration_discovery_service_proto_lib"],
+    name = "configuration_discovery_service_cc_proto",
+    deps = [":configuration_discovery_service_proto_lib"],
 )
 
 cc_grpc_library(
-  name = "configuration_discovery_service_cc_grpc",
-  srcs = [":configuration_discovery_service_proto_lib"],
-  deps = [":configuration_discovery_service_cc_proto"],
-  grpc_only = True,
-  generate_mocks = True,
+    name = "configuration_discovery_service_cc_grpc",
+    srcs = [":configuration_discovery_service_proto_lib"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":configuration_discovery_service_cc_proto"],
 )


### PR DESCRIPTION
#### Description

This PR updates Bazel build configuration to use bzlmod, following https://bazel.build/external/migration . The main changes include upgrading `grpc`, `protobuf`, and `rules_proto`, updating repository loading logic to avoid redundant downloads, and adjusting build files to use the updated dependency structure.

